### PR TITLE
rewrote when calling autoselect of metadata in scoresheet

### DIFF
--- a/client/components/scoresheet/metadata_inputs/metadata_inputs_controller.js
+++ b/client/components/scoresheet/metadata_inputs/metadata_inputs_controller.js
@@ -1,7 +1,5 @@
 import Promise from 'bluebird'
 
-import debounce from '../../../lib/debounce'
-
 class MetadataInputsController {
   constructor (scoresheet, scores, $scope, $location, tournament, refIdentity, logger) {
     Object.assign(this, { data: scoresheet, scores, $scope, $location, tournament, refIdentity, logger })
@@ -9,24 +7,20 @@ class MetadataInputsController {
   }
 
   $onInit () {
-    this.$scope.$watch(() => this.teamNumber(), () => {
-      if (this.teamNumber()) {
-        this.forceMatchReselection = true
-        this.loadMatchOptions()
-          .then(() => this.autoselectMatch())
-          .catch(error => this.logger.error(error))
-      }
-    })
-
     this.$scope.$watch(() => this.stage(), () => this.syncMatchFields())
     this.$scope.$watch(() => this.round(), () => this.syncMatchFields())
     this.$scope.$watch(() => this.matchId(), () => this.syncMatchFields())
 
-    this.$scope.$on('load', () => { this.data.autoselect = false })
-    this.$scope.$on('reset', () => {
-      this.data.autoselect = true
-      this.forceTeamReselection = true
-      this.autoselectMetadata()
+    this.$scope.$watch(() => this.teamNumber(), () => {
+      if (this.teamNumber()) {
+        if (this.data.isEditing()) {
+          this.loadMatchOptions()
+            .then(() => this.syncMatchFields())
+            .catch(error => this.logger.error(error))
+        } else {
+          this.autoselectMatch()
+        }
+      }
     })
 
     this.scores.on('scores updated', () => {
@@ -35,11 +29,13 @@ class MetadataInputsController {
       }
     })
 
-    this.debouncedAutoselectMetadata = debounce(() => this.autoselectMetadata())
     this.refIdentity.on('table changed', () => {
-      if (this.refIdentity.table) {
-        this.forceTeamReselection = true
-        this.debouncedAutoselectMetadata()
+      this.autoselectMetadata()
+    })
+
+    this.$scope.$on('reset', (_event, { forceMetadataIfEditing }) => {
+      if (!this.data.isEditing() || !forceMetadataIfEditing || !this.teamNumber()) {
+        this.autoselectMetadata()
       }
     })
 
@@ -48,10 +44,7 @@ class MetadataInputsController {
     })
 
     Promise.all([this.data.init(), this.tournament.loadTeams(), this.refIdentity.init()])
-      .then(() => {
-        this.loadFromUrl()
-        return this.autoselectMetadata()
-      })
+      .then(() => this.loadFromUrl())
       .catch(error => this.logger.error(error))
   }
 
@@ -74,7 +67,6 @@ class MetadataInputsController {
   loadFromUrl () {
     const search = this.$location.search()
     if (search.teamNumber && isFinite(search.teamNumber)) {
-      this.data.autoselect = true
       this.data.current.teamNumber = parseInt(search.teamNumber)
       if (search.stage) {
         this.data.current.stage = search.stage
@@ -82,21 +74,15 @@ class MetadataInputsController {
       if (search.round && isFinite(search.round)) {
         this.data.current.round = parseInt(search.round)
       }
-      this.data.autoselect = false
     }
   }
 
   autoselectMetadata () {
-    if (!this.data.autoselect) {
-      return this.loadMatchOptions()
-        .then(() => this.syncMatchFields())
-        .then(() => this.data.process())
-    }
     this.autoselecting = true
     return this.autoselectTeam()
       .then(() => {
         if (this.data.current.teamNumber) {
-          return this.loadMatchOptions().then(() => this.autoselectMatch())
+          return this.autoselectMatch()
         }
       })
       .catch(error => this.logger.error(error))
@@ -107,19 +93,21 @@ class MetadataInputsController {
     if (!this.refIdentity.table) {
       return Promise.resolve()
     }
-    if (!this.forceTeamReselection) {
-      if (!this.data.autoselect) {
-        return Promise.resolve()
-      }
-      if (this.data.current.teamNumber !== undefined) {
-        return Promise.resolve()
-      }
-    }
-    this.forceTeamReselection = false
     return this.tournament.loadNextTeamForTable(this.refIdentity.table.tableId, this.data.lastMatchId)
       .then(teamNumber => {
         if (teamNumber) {
           this.data.current.teamNumber = teamNumber
+        }
+      })
+  }
+
+  autoselectMatch () {
+    return this.loadMatchOptions()
+      .then(() => {
+        const firstIncompleteMatch = this.matches.find(match => !match.complete)
+        if (firstIncompleteMatch) {
+          this.data.current.stage = firstIncompleteMatch.stage
+          this.data.current.round = firstIncompleteMatch.round
         }
       })
   }
@@ -141,30 +129,6 @@ class MetadataInputsController {
         this.loadingMatches = false
         return this.data.process()
       })
-  }
-
-  autoselectMatch () {
-    if (!this.data.autoselect) {
-      return Promise.resolve()
-    }
-    if (!this.forceMatchReselection) {
-      if (this.data.current.matchId !== undefined) {
-        return Promise.resolve()
-      }
-      if (this.data.current.round !== undefined && this.data.current.stage !== undefined) {
-        return Promise.resolve()
-      }
-      if (this.matches.some(match => this.data.current.stage === match.stage || this.data.current.round === match.round)) {
-        return Promise.resolve()
-      }
-    }
-    this.forceMatchReselection = false
-    const firstIncompleteMatch = this.matches.find(match => !match.complete)
-    if (firstIncompleteMatch) {
-      this.data.current.stage = firstIncompleteMatch.stage
-      this.data.current.round = firstIncompleteMatch.round
-    }
-    return Promise.resolve()
   }
 
   calculateMatchCompletion () {

--- a/client/components/scoresheet/metadata_inputs/metadata_inputs_controller.js
+++ b/client/components/scoresheet/metadata_inputs/metadata_inputs_controller.js
@@ -1,8 +1,8 @@
 import Promise from 'bluebird'
 
 class MetadataInputsController {
-  constructor (scoresheet, scores, $scope, $location, tournament, refIdentity, logger) {
-    Object.assign(this, { data: scoresheet, scores, $scope, $location, tournament, refIdentity, logger })
+  constructor (scoresheet, scores, $scope, $location, tournament, refIdentity, user, logger) {
+    Object.assign(this, { data: scoresheet, scores, $scope, $location, tournament, refIdentity, user, logger })
     this.loading = true
   }
 
@@ -30,13 +30,13 @@ class MetadataInputsController {
     })
 
     this.refIdentity.on('table changed', () => {
-      if (!this.data.isEditing()) {
+      if (!this.data.isEditing() && !this.user.isAdmin()) {
         this.autoselectMetadata()
       }
     })
 
     this.$scope.$on('reset', (_event, { forceMetadataIfEditing }) => {
-      if (!this.data.isEditing() || !forceMetadataIfEditing || !this.teamNumber()) {
+      if ((!this.data.isEditing() || !forceMetadataIfEditing || !this.teamNumber()) && !this.user.isAdmin()) {
         this.autoselectMetadata()
       }
     })
@@ -159,6 +159,6 @@ class MetadataInputsController {
 }
 
 MetadataInputsController.$$ngIsClass = true
-MetadataInputsController.$inject = ['scoresheet', 'scores', '$scope', '$location', 'tournament', 'refIdentity', 'logger']
+MetadataInputsController.$inject = ['scoresheet', 'scores', '$scope', '$location', 'tournament', 'refIdentity', 'user', 'logger']
 
 export default MetadataInputsController

--- a/client/components/scoresheet/metadata_inputs/metadata_inputs_controller.js
+++ b/client/components/scoresheet/metadata_inputs/metadata_inputs_controller.js
@@ -30,7 +30,9 @@ class MetadataInputsController {
     })
 
     this.refIdentity.on('table changed', () => {
-      this.autoselectMetadata()
+      if (!this.data.isEditing()) {
+        this.autoselectMetadata()
+      }
     })
 
     this.$scope.$on('reset', (_event, { forceMetadataIfEditing }) => {

--- a/client/components/scoresheet/scoresheet_page/scoresheet_page_controller.js
+++ b/client/components/scoresheet/scoresheet_page/scoresheet_page_controller.js
@@ -20,10 +20,6 @@ class ScoresheetPageController {
     this.$scope.$on('reset scoresheet', () => this.reset(false))
     this.$scope.$on('cancel scoresheet', () => this.reset(true))
 
-    this.$scope.$on('$locationChangeSuccess', () => {
-      this.loadFromURL()
-    })
-
     this.data.on('processed', () => {
       if (!this._previouslyComplete && this.complete()) {
         this._previouslyComplete = true
@@ -31,9 +27,10 @@ class ScoresheetPageController {
       }
     })
 
-    Promise.all([this.data.init(), this.scores.init()])
+    return Promise.all([this.data.init(), this.scores.init()])
       .then(() => {
         this.loadFromURL()
+        this.$scope.$on('$locationChangeSuccess', () => this.loadFromURL())
         this.ready = true
         return true
       })
@@ -91,12 +88,15 @@ class ScoresheetPageController {
     const splitPath = this.$location.path().split('/')
     const page = splitPath[1]
     const subpage = splitPath[2]
-    if (page === 'scoresheet' && subpage !== 'new') {
-      const score = this.scores.scores.find(s => s._id === subpage)
-      if (score !== undefined) {
-        this.data.autoselect = false
-        this.data.load(score)
-        this.scrollDisabled = true
+    if (page === 'scoresheet') {
+      if (subpage === 'new') {
+        this.reset()
+      } else {
+        const score = this.scores.scores.find(s => s._id === subpage)
+        if (score !== undefined) {
+          this.data.load(score)
+          this.scrollDisabled = true
+        }
       }
     }
   }

--- a/client/services/scoresheet/ref_identity.js
+++ b/client/services/scoresheet/ref_identity.js
@@ -15,23 +15,30 @@ class RefIdentity extends EventEmitter {
         if (tables.length === 0) {
           this.tablesDisabled = true
         }
+        this.initWatchers()
         const data = JSON.parse(this.$window.sessionStorage[STORAGE_KEY] || EMPTY_DATA)
         this.set(data)
         return this
       })
     }
 
-    this.$rootScope.$watch(() => this.referee, () => {
-      this.emit('referee changed')
-    })
-
-    this.$rootScope.$watch(() => (this.table ? this.table.tableId : undefined), (newValue, oldValue) => {
-      if (newValue !== oldValue) {
-        this.emit('table changed')
-      }
-    })
-
     return this._initPromise
+  }
+
+  initWatchers () {
+    if (!this.watchersInitizlied) {
+      this.watchersInitizlied = true
+
+      this.$rootScope.$watch(() => this.referee, () => {
+        this.emit('referee changed')
+      })
+
+      this.$rootScope.$watch(() => (this.table ? this.table.tableId : undefined), (newValue, oldValue) => {
+        if (newValue !== oldValue) {
+          this.emit('table changed')
+        }
+      })
+    }
   }
 
   set (data) {

--- a/client/services/scoresheet/scoresheet.js
+++ b/client/services/scoresheet/scoresheet.js
@@ -18,7 +18,6 @@ class Scoresheet extends EventEmitter {
     this.errors = []
     this.ready = false
     this.faulty = false
-    this.autoselect = true
   }
 
   init () {
@@ -144,7 +143,6 @@ class Scoresheet extends EventEmitter {
 
   load (score) {
     this.ready = false
-    this.autoselect = false
     return Promise.resolve(this.refIdentity.set(score))
       .then(() => {
         Object.assign(this.current, {

--- a/client/services/utils/independence.js
+++ b/client/services/utils/independence.js
@@ -21,7 +21,6 @@ class Independence {
 
   send (method, url, data) {
     const action = { method, url, data, pending: false }
-    this._saveRequest(action)
     return this._requestPromise(action)
   }
 
@@ -33,13 +32,12 @@ class Independence {
 
   _requestPromise (action) {
     action.pending = true
-    this._saveRequest(action)
     return this.$http[action.method.toLowerCase()](action.url, action.data)
       .then(response => {
         if (response.status <= 0) {
+          this._saveRequest(action)
           throw response
         }
-        this._deleteRequest(action)
         this.retrySavedRequest()
         return response
       })


### PR DESCRIPTION
Please double check the related features in scoring: editing, selecting teams and matches, canceling, clearing, chaning tables and submitting the scores.
I've narrowed the autoselect feature to occour on the following events:
1. Table has changed (not while editing)
2. Team has changed
3. Reseting to a new scoresheet page (opening it from scores page or clicking cancel or reset, not while editing)
In any other case there should not be autoselect. If there is please tell me and I'll fix it, the code is much easier now (not that I changed much...)